### PR TITLE
Add support for returning a string without passing an object as parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ module.exports = function (template, args) {
 };
 
 function interpolate(template, args) {
+  if (typeof args === 'undefined') {
+    args = {};
+  }
   return template.replace(/{([^}]*)}/g, function (match, key) {
     return key in args ? args[key] : match;
   });

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var format = require('./index.js');
 
 describe('format', function () {
-  it('should replace denoated keys with corresponding values', function() {
+  it('should replace denoted keys with corresponding values', function() {
     var formatted = format('{greeting} {thing}!', {
       greeting: 'Hello',
       thing: 'world'
@@ -35,5 +35,19 @@ describe('format', function () {
     var formatted = formatFunc({ greeting: 'howdy' });
 
     assert.strictEqual(formatted, 'howdy do!');
+  });
+
+  it('should return a string if an object is not supplied to the function', function() {
+    var formatFunc = format('Hi there!');
+    var formatted = formatFunc();
+
+    assert.strictEqual(formatted, 'Hi there!');
+  });
+
+  it('should return a string with unsatisfied keys unchanged if an object is not supplied to the function', function() {
+    var formatFunc = format('Hi {name}!');
+    var formatted = formatFunc();
+
+    assert.strictEqual(formatted, 'Hi {name}!');
   });
 });


### PR DESCRIPTION
**Change:**

If I have a template without any tokens in it:
```
var tpl = format('Hello');
```
The current implementation still requires me to send an empty object for getting the formatted string:
```
var string = tpl({});
```

This PR makes the object parameter optional so that the templates can be used as:
```
var string = tpl();
```

**Why do I need formatted strings without token?**

I'm keeping all of my endpoints as formatted templates even if they don't have any dynamic token in them. This allows me to add support for token later on without requiring too many changes in the code.